### PR TITLE
Increasing font size for drug name and quantity

### DIFF
--- a/static/css/common.css
+++ b/static/css/common.css
@@ -83,9 +83,12 @@ div.specialPrescriptionToggle span.specialPrescriptionLabel {
   flex-direction: row;
 }
 .receitaItem .printable-drug-text {
-  font-family: monospace;
-  font-size: 12pt;
   display: none;
+}
+.receitaItem .printable-drug-text::first-line {
+  font-family: monospace;
+  font-weight: bold;
+  font-size: larger;
 }
 .receitaItem .drug-text-wrapper {
   flex: 2;


### PR DESCRIPTION
Keeping monospaced font, but making it bold and larger.
Other drug instructions are sans-serif, for improved reading.