### PR TITLE
Reading drugs from Google AppEngine Datastore instead of JSON

### DIFF
--- a/scripts/drug.py
+++ b/scripts/drug.py
@@ -28,13 +28,20 @@ def from_entity(entity: Entity) -> Drug:
     drug = Drug()
     drug.id = entity['id']
     drug.name = entity['name']
-    drug.quantity = entity['quantity']
-    drug.instructions = entity['instructions']
-    drug.brand = entity['brand']
-    drug.category = entity['category']
-    drug.subcategory = entity['subcategory']
-    drug.is_link = entity['is_link']
-    drug.is_image = entity['is_image']
+    if 'quantity' in entity:
+        drug.quantity = entity['quantity']
+    if 'instructions' in entity:
+        drug.instructions = entity['instructions']
+    if 'brand' in entity:
+        drug.brand = entity['brand']
+    if 'category' in entity:
+        drug.category = entity['category']
+    if 'subcategory' in entity:
+        drug.subcategory = entity['subcategory']
+    if 'is_link' in entity:
+        drug.is_link = entity['is_link']
+    if 'is_image' in entity:
+        drug.is_image = entity['is_image']
     return drug
 
 

--- a/scripts/drug.py
+++ b/scripts/drug.py
@@ -1,8 +1,10 @@
 import dataclasses
 from typing import Any
+from google.cloud import datastore
+from google.cloud.datastore.entity import Entity
 
 
-@dataclasses.dataclass(init=False)
+@dataclasses.dataclass(init=False, frozen=False)
 class Drug:
     id: int
     name: str
@@ -13,6 +15,27 @@ class Drug:
     subcategory: str = None
     is_link: bool = False
     is_image: bool = False
+
+
+def to_entity(drug: Drug, client: datastore.Client) -> Entity:
+    entity = Entity(key=client.key('drug', drug.id))
+    for field, value in dataclasses.asdict(drug).items():
+        entity[field] = value
+    return entity
+
+
+def from_entity(entity: Entity) -> Drug:
+    drug = Drug()
+    drug.id = entity['id']
+    drug.name = entity['name']
+    drug.quantity = entity['quantity']
+    drug.instructions = entity['instructions']
+    drug.brand = entity['brand']
+    drug.category = entity['category']
+    drug.subcategory = entity['subcategory']
+    drug.is_link = entity['is_link']
+    drug.is_image = entity['is_image']
+    return drug
 
 
 def from_json(obj: Any) -> Drug:

--- a/scripts/drugs_datastore.py
+++ b/scripts/drugs_datastore.py
@@ -1,0 +1,17 @@
+from typing import List
+from scripts import drug, storage
+from google.cloud import datastore
+
+class DrugsDatastore(storage.DrugsStorage):
+    def __init__(self):
+        self._datastore_client = datastore.Client(project='hellodpiresworld')
+
+
+    def fetch_drugs(self) -> List[drug.Drug]:
+        query = self._datastore_client.query(kind='drug')
+        entities = query.fetch(limit=3000)
+        return [drug.from_entity(entity) for entity in entities]
+
+
+    def update_drug_definitions(self, drugs_list: List[drug.Drug]):
+        raise NotImplementedError()

--- a/scripts/load_drugs_to_datastore.py
+++ b/scripts/load_drugs_to_datastore.py
@@ -1,0 +1,17 @@
+import json
+from scripts import drug
+from google.cloud import datastore
+
+with open('../drugs.json', 'r') as f:
+    myjson = json.load(f)
+
+client = datastore.Client(project='hellodpiresworld')
+drugs = [drug.from_json(j) for j in myjson]
+entities = [drug.to_entity(d, client) for d in drugs]
+
+# entities = entities[100:105]
+with client.transaction():
+    client.put_multi(entities)
+
+e1 = client.get(key=client.key('drug', 102))
+d1 = drug.from_entity(e1)

--- a/scripts/storage_defs.py
+++ b/scripts/storage_defs.py
@@ -1,9 +1,10 @@
-from scripts import on_disk_drugs_storage, on_disk_support_icons_storage, appengine_datastore_footnotes, storage
+from scripts import drugs_datastore, on_disk_support_icons_storage, appengine_datastore_footnotes, storage
 
 
 class Storage:
     def __init__(self):
-        self._drugs = on_disk_drugs_storage.OnDiskDrugStorage()
+        self._drugs = drugs_datastore.DrugsDatastore()
+        # self._drugs = on_disk_drugs_storage.OnDiskDrugStorage()
         self._footnotes = appengine_datastore_footnotes.AppEngineDataStoreFootnotes()
         # self._footnotes = jinja_footnotes.JinjaFootnotesStorage()
         self._support_icons = on_disk_support_icons_storage.OnDiskSupportIconsStorage()


### PR DESCRIPTION
This moves the reading of drugs from JSON file to AppEngine datastore.

I am also including a script that loads the drugs from the JSON and adds them to the datastore. 

Fixes #2: now only those with access to the AppEngine console can add/edit/remove drugs.
Fixes #19: images with blocks of icons are already in the database.
