### PR TITLE
Instructions for doctors

### DIFF
--- a/scripts/drug.py
+++ b/scripts/drug.py
@@ -10,6 +10,7 @@ class Drug:
     name: str
     quantity: str = None
     instructions: str = None
+    instructions_for_doctors: str = None
     brand: str = None
     category: str = None
     subcategory: str = None
@@ -32,6 +33,8 @@ def from_entity(entity: Entity) -> Drug:
         drug.quantity = entity['quantity']
     if 'instructions' in entity:
         drug.instructions = entity['instructions']
+    if 'instructions_for_doctors' in entity:
+        drug.instructions_for_doctors = entity['instructions_for_doctors']
     if 'brand' in entity:
         drug.brand = entity['brand']
     if 'category' in entity:

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -108,6 +108,17 @@ div.specialPrescriptionToggle span.specialPrescriptionLabel {
   max-width: 80%;
 }
 
+/* Instructions for doctors */
+.instructions-for-doctors {
+    padding: 5px;
+    margin: 10px;
+    border-radius: 5px;
+    background-color: #FAA;
+}
+.instructions-for-doctors button {
+    float: right;
+}
+
 /* General organization */
 div.collapsed {
   display: none;

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -147,7 +147,8 @@ div.collapsed {
   .attribution,
   button,
   textarea,
-  .group-by-route img.unchecked {
+  .group-by-route img.unchecked,
+  .instructions-for-doctors {
     display: none;
   }
   input {

--- a/static/css/icon_select.css
+++ b/static/css/icon_select.css
@@ -1,14 +1,16 @@
-.icon-select .selected-icons {
-    height: 64px;
-    display: inline-block;
-    margin: 1em 0;
-}
 .icon-select .show-options {
     float: right;
 }
 .icon-select img {
     width: 60px;
     height: 60px;
+}
+.icon-select .selected-icons {
+    display: inline-block;
+    margin: 0.1em;
+}
+.icon-select .selected-icons img {
+    margin: 2px;
 }
 .icon-select .icon-options {
     background-color: white;

--- a/static/js/instructions_for_doctors.js
+++ b/static/js/instructions_for_doctors.js
@@ -1,0 +1,22 @@
+export class InstructionsForDoctors {
+    constructor(_drug, _parent) {
+        this.drug = _drug;
+        this.parent = _parent;
+    }
+
+    render = function() {
+        this.root = document.createElement('div');
+        this.root.classList.add('instructions-for-doctors');
+        this.closeBtn = document.createElement('button');
+        this.closeBtn.innerText = 'X';
+        this.text = document.createElement('p');
+        this.text.innerText = this.drug['instructions_for_doctors'];
+        this.closeBtn.addEventListener('click', (function (e) {
+            this.parent.style.display = 'none';
+        }).bind(this));
+
+        this.root.appendChild(this.closeBtn);
+        this.root.appendChild(this.text);
+        this.parent.appendChild(this.root);
+    }
+}

--- a/static/js/receitaDiv.js
+++ b/static/js/receitaDiv.js
@@ -1,4 +1,5 @@
 import IconSelect from './iconSelect.js';
+import { InstructionsForDoctors } from './instructions_for_doctors.js';
 
 class CustomizedTextHandler {
   constructor(receitaDiv, drugPosition, printableTextDiv, drugTextArea) {
@@ -113,7 +114,7 @@ export default class ReceitaDiv {
     textarea.value = drugText;
     printableText.innerText = drugText;
     var customTextHandler = new CustomizedTextHandler(this, position, printableText, textarea);
-
+    
     textarea.addEventListener('keyup', this.handleCustomizedText.bind(customTextHandler));
     listItem.appendChild(posSpan);
     drugTextWrapper.appendChild(textarea);
@@ -121,6 +122,16 @@ export default class ReceitaDiv {
     listItem.appendChild(drugTextWrapper);
     listItem.appendChild(iconSelector.root);
     this.prescriptionDiv.appendChild(listItem);
+    
+    // Add instructions for doctors, if available.
+    if ('instructions_for_doctors' in drugData) {
+        var liForInstructions = document.createElement('li');        
+        var instructionsForDoctors = new InstructionsForDoctors(
+            drugData,
+            liForInstructions);
+        instructionsForDoctors.render();   
+        this.prescriptionDiv.appendChild(liForInstructions);
+    }
 
     // Need to do this after the textarea is appended to the doc.
     textarea.style.height = '';


### PR DESCRIPTION
Adding instructions for doctors, using the `instructions_for_doctors` property from datastore.

The boxes are shown in a new list item in the receitaDiv. There is an `X` button on the top-right corner that allows closing the box - actually, giving it a `display: none` style. The box is not visible when printing.

Also improves a little bit the spacing between icons in the icon-selector.

Fixes #9 : now you can add the relevant info on the datastore and it is visible on the website.