### PR TITLE
Making instructions for doctors permanently closed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask==2.0.3
+flask==2.3.2
+google-cloud-datastore
 google-cloud-storage
-google-cloud-datastore==2.7.1

--- a/static/js/instructions_for_doctors.js
+++ b/static/js/instructions_for_doctors.js
@@ -1,7 +1,6 @@
 export class InstructionsForDoctors {
     constructor(_drug, _parent) {
         this.drug = _drug;
-        this.parent = _parent;
         this.isClosedBtnClicked = false;
     }
 
@@ -17,12 +16,12 @@ export class InstructionsForDoctors {
         this.text = document.createElement('p');
         this.text.innerText = this.drug['instructions_for_doctors'];
         this.closeBtn.addEventListener('click', (function (e) {
-            this.parent.style.display = 'none';
+            parent.style.display = 'none';
             this.isClosedBtnClicked = true;
         }).bind(this));
 
         this.root.appendChild(this.closeBtn);
         this.root.appendChild(this.text);
-        this.parent.appendChild(this.root);
+        parent.appendChild(this.root);
     }
 }

--- a/static/js/instructions_for_doctors.js
+++ b/static/js/instructions_for_doctors.js
@@ -2,9 +2,14 @@ export class InstructionsForDoctors {
     constructor(_drug, _parent) {
         this.drug = _drug;
         this.parent = _parent;
+        this.isClosedBtnClicked = false;
     }
 
-    render = function() {
+    isClosed = function() {
+        return this.isClosedBtnClicked;
+    }
+
+    render = function(parent) {
         this.root = document.createElement('div');
         this.root.classList.add('instructions-for-doctors');
         this.closeBtn = document.createElement('button');
@@ -13,6 +18,7 @@ export class InstructionsForDoctors {
         this.text.innerText = this.drug['instructions_for_doctors'];
         this.closeBtn.addEventListener('click', (function (e) {
             this.parent.style.display = 'none';
+            this.isClosedBtnClicked = true;
         }).bind(this));
 
         this.root.appendChild(this.closeBtn);

--- a/static/js/receitaDiv.js
+++ b/static/js/receitaDiv.js
@@ -21,6 +21,7 @@ export default class ReceitaDiv {
     this.prescriptionDiv = null;
     this.drugCustomText = {};
     this.drugSupportIconSelectors = {};
+    this.drugInstructions = {};
   }
 
   handleIconClick = function (e) {
@@ -92,6 +93,7 @@ export default class ReceitaDiv {
 
   addDrug = function (drugData) {
     var position = drugData['position'];
+    var drugId = drugData['id'];
     if (!(position in this.drugCustomText)) {
       this.drugCustomText[position] = this.getTextForDrug(drugData);
     }
@@ -108,13 +110,13 @@ export default class ReceitaDiv {
     listItem.classList = ['receitaItem'];
     drugTextWrapper.classList = ['drug-text-wrapper'];
     printableText.classList = ['printable-drug-text'];
-    listItem.setAttribute('id', 'drug' + drugData['id']);
+    listItem.setAttribute('id', 'drug' + drugId);
     textarea.setAttribute('cols', 60);
 
     textarea.value = drugText;
     printableText.innerText = drugText;
     var customTextHandler = new CustomizedTextHandler(this, position, printableText, textarea);
-    
+
     textarea.addEventListener('keyup', this.handleCustomizedText.bind(customTextHandler));
     listItem.appendChild(posSpan);
     drugTextWrapper.appendChild(textarea);
@@ -122,15 +124,23 @@ export default class ReceitaDiv {
     listItem.appendChild(drugTextWrapper);
     listItem.appendChild(iconSelector.root);
     this.prescriptionDiv.appendChild(listItem);
-    
+
     // Add instructions for doctors, if available.
     if ('instructions_for_doctors' in drugData) {
-        var liForInstructions = document.createElement('li');        
-        var instructionsForDoctors = new InstructionsForDoctors(
-            drugData,
-            liForInstructions);
-        instructionsForDoctors.render();   
+      var liForInstructions = document.createElement('li');
+      var instructionsForDoctors = null;
+      if (drugId in this.drugInstructions) {
+        instructionsForDoctors = this.drugInstructions[drugId];
+      } else {
+        instructionsForDoctors = new InstructionsForDoctors(
+          drugData,
+          liForInstructions);
+        this.drugInstructions[drugId] = instructionsForDoctors;
+      }
+      if (!instructionsForDoctors.isClosed()) {
+        instructionsForDoctors.render();
         this.prescriptionDiv.appendChild(liForInstructions);
+      }
     }
 
     // Need to do this after the textarea is appended to the doc.

--- a/static/js/receitaDiv.js
+++ b/static/js/receitaDiv.js
@@ -127,18 +127,16 @@ export default class ReceitaDiv {
 
     // Add instructions for doctors, if available.
     if ('instructions_for_doctors' in drugData) {
-      var liForInstructions = document.createElement('li');
       var instructionsForDoctors = null;
       if (drugId in this.drugInstructions) {
         instructionsForDoctors = this.drugInstructions[drugId];
       } else {
-        instructionsForDoctors = new InstructionsForDoctors(
-          drugData,
-          liForInstructions);
+        instructionsForDoctors = new InstructionsForDoctors(drugData);
         this.drugInstructions[drugId] = instructionsForDoctors;
       }
       if (!instructionsForDoctors.isClosed()) {
-        instructionsForDoctors.render();
+        var liForInstructions = document.createElement('li');
+        instructionsForDoctors.render(liForInstructions);
         this.prescriptionDiv.appendChild(liForInstructions);
       }
     }


### PR DESCRIPTION
Currently, if you close the instructions for doctors, then add a new drug, the box is redrawn.

This is because we redraw the prescription at each "event", so we need to store the information on whether the button was clicked, and only re-add the box if it was not yet clicked.

This change makes it store the information on whether the close button was clicked, and only recreate the InformationForDoctors once for each drug.