### PR TITLE
Splits 'Pack de imagens' in 4 categories, one for each route

### DIFF
--- a/main.py
+++ b/main.py
@@ -154,34 +154,14 @@ def support_icons_defs():
     return Response(contents, mimetype='application/json')
 
 
-@app.route('/bibliografia')
-def fetch_bibliography():
-    return knowledge_base.render_bibliography_page(app)
-
-
 @app.route('/biblioteca')
 def fetch_library():
     return knowledge_base.render_library_page(app)
 
 
-@app.route('/documentos')
-def fetch_documents():
-    return knowledge_base.render_documents_page(app)
-
-
-@app.route('/scores')
-def fetch_scores():
-    return knowledge_base.render_scores_page(app)
-
-
 @app.route('/materiais')
 def fetch_materials():
     return knowledge_base.render_materials_page(app)
-
-
-@app.route('/painel')
-def fetch_panel():
-    return knowledge_base.render_panel_page(app)
 
 
 if __name__ == '__main__':

--- a/scripts/knowledge_base.py
+++ b/scripts/knowledge_base.py
@@ -31,21 +31,9 @@ def _fetch_from_storage(pagename):
 			            blobs=blobs)
 
 
-def render_bibliography_page(app):
-	return _fetch_from_storage("bibliografia")
-
 def render_library_page(app):
 	return _fetch_from_storage("biblioteca")
 
-def render_documents_page(app):
-	return _fetch_from_storage("documentos")
-
-def render_scores_page(app):
-	return _fetch_from_storage("scores")
-
 def render_materials_page(app):
 	return _fetch_from_storage("materiais")
-
-def render_panel_page(app):
-	return _fetch_from_storage("painel")
 

--- a/static/js/drugsForm.js
+++ b/static/js/drugsForm.js
@@ -181,7 +181,7 @@ export default class DrugsForm {
       "<option value='Encaminhamento'>Encaminhamento</option>" +
       "<option value='Retorno'>Retorno</option>" +
       "<option value='Retorno'>Atestado</option>" +
-      "<option value='Retorno'>Solicitação de exames</option>" +
+      "<option value='Solicitação de exames'>Solicitação de exames</option>" +
       "</select>";
     var selectorDiv = document.createElement("div");
     selectorDiv.id = 'route-selector';

--- a/static/js/drugsForm.js
+++ b/static/js/drugsForm.js
@@ -95,7 +95,10 @@ export default class DrugsForm {
         'DIGITAR QUALQUER MEDICAMENTO',
         'SALA DE PROCEDIMENTOS',
         'Imagens',
-        'Packs de imagens',
+        'Packs de ícones (Comprimido)',
+        'Packs de ícones (Cápsula)',
+        'Packs de ícones (Líquido)',
+        'Packs de ícones (Tópico)',
         'Videos',
         'VALIDADE'];
     specialCategories.forEach(this.buildCategory.bind(this));

--- a/templates/knowledge_base.html
+++ b/templates/knowledge_base.html
@@ -27,9 +27,7 @@
         <ul>
           <li><a href="/">Receitas</a></li>
           <li><a href="/biblioteca">Biblioteca</a></li>
-          <li><a href="/documentos">Documentos</a></li>
           <li><a href="/materiais">Materiais</a></li>
-          <li><a href="/painel">Painel</a></li>
         </ul>
       </div>
       <div id='contents'>

--- a/templates/main.html
+++ b/templates/main.html
@@ -32,9 +32,7 @@
             <ul>
                 <li><a href="/">Receitas</a></li>
                 <li><a href="/biblioteca">Biblioteca</a></li>
-                <li><a href="/documentos">Documentos</a></li>
                 <li><a href="/materiais">Materiais</a></li>
-                <li><a href="/painel">Painel</a></li>
             </ul>
         </div>
         <div class="main-column">


### PR DESCRIPTION
Continuing work on #22: splits the category 'Packs de imagens' in 4 different categories, one for each route.

The drugs have already been updated in the datastore. 