### PR TITLE
Bug fix: use datastore id if field missing.

### DIFF
--- a/scripts/drug.py
+++ b/scripts/drug.py
@@ -27,7 +27,11 @@ def to_entity(drug: Drug, client: datastore.Client) -> Entity:
 
 def from_entity(entity: Entity) -> Drug:
     drug = Drug()
-    drug.id = entity['id']
+    if 'id' in entity:
+        drug.id = entity['id']
+    else:
+        drug.id = entity.key.id
+
     drug.name = entity['name']
     if 'quantity' in entity:
         drug.quantity = entity['quantity']


### PR DESCRIPTION
When we create drugs from the Console UI, we cannot enforce that the ID field is set. Therefore it can be missing. 

In these cases, we switch to reading it from the datastore key.