### PR TITLE
Only set iconSelector.selectedUrls when instantiating the IconSelector for first time.

### DIFF
--- a/static/js/receitaDiv.js
+++ b/static/js/receitaDiv.js
@@ -99,14 +99,15 @@ export default class ReceitaDiv {
     }
     var drugText = this.drugCustomText[position];
     if (!(position in this.drugSupportIconSelectors)) {
-      this.drugSupportIconSelectors[position] = new IconSelect();
+      var newIconSelector = new IconSelect();
+      if (drugData['support_icons'] && drugData['support_icons'] != '') {
+        var iconUrls = drugData['support_icons'].split(',');
+        newIconSelector.selectedUrls = iconUrls;
+        newIconSelector.buildOptions();
+      }
+      this.drugSupportIconSelectors[position] = newIconSelector;
     }
     var iconSelector = this.drugSupportIconSelectors[position];
-    if (drugData['support_icons'] && drugData['support_icons'] != '') {
-      var iconUrls = drugData['support_icons'].split(',');
-      iconSelector.selectedUrls = iconUrls;
-      iconSelector.buildOptions();
-    }
     var listItem = document.createElement('li');
     var posSpan = document.createElement('span');
     var drugTextWrapper = document.createElement('div');


### PR DESCRIPTION
Currently, every time we refresh the receitaDiv, we reset the iconSelector of each drug with the preselected icons from the DB. This pull request makes it reset the field only the first time that the IconSelect is created.

Fixes #45.