### PR TITLE
Setting max width for prescribed images in drugs.

### DIFF
--- a/static/css/common.css
+++ b/static/css/common.css
@@ -97,6 +97,7 @@ div.specialPrescriptionToggle span.specialPrescriptionLabel {
 } 
 .receitaItem img.img-for-patient {
   display: block;
+  max-width: 80%;
 }
 .receitaItem div.qr-code {
   display: flex;  


### PR DESCRIPTION
right now, set to 80% of the page width.