### PR TITLE
Resizing support icons div leaving 4 per row

### DIFF
--- a/scripts/on_disk_support_icons_storage.py
+++ b/scripts/on_disk_support_icons_storage.py
@@ -19,5 +19,6 @@ class OnDiskSupportIconsStorage(support_icon_storage.SupportIconsStorage):
             category, _ = blob.name.split('/')
             if category not in support_icon_defs:
                 support_icon_defs[category] = []
-            support_icon_defs[category].append(blob.public_url)
+            if blob.public_url and blob.public_url.endswith('.png'):
+                support_icon_defs[category].append(blob.public_url)
         return support_icon_defs

--- a/static/css/icon_select.css
+++ b/static/css/icon_select.css
@@ -2,13 +2,13 @@
     float: right;
 }
 .icon-select img {
-    width: 80px;
-    height: 80px;
+    width: auto;
+    height: 104px;
 }
 .icon-select .selected-icons {
     display: flex;
     flex-wrap: nowrap;
-    margin: 0.1em;
+    margin: 1em;
 }
 .icon-select .selected-icons img {
     margin: 2px;
@@ -16,7 +16,7 @@
 .icon-select .icon-options {
     background-color: white;
     float: right;
-    width: 448px;
+    width: 800px;
 }
 .icon-select .icon-options div.category {
     margin: 10px 0 0 0;

--- a/static/js/iconSelect.js
+++ b/static/js/iconSelect.js
@@ -6,6 +6,7 @@ var removeAllChildren = function (parent) {
 
 var SUPPORT_ICON_DEFS = null;
 var INCLUDED_CATEGORIES = new Set([
+  'Combinados',
   'Via de uso',
   'Motivo do uso',
   'Horários',
@@ -96,9 +97,12 @@ export default class IconSelect {
         continue;
       }
       var categoryHeader = document.createElement('div');
-      categoryHeader.innerText = headerText;
       var categoryContents = document.createElement('div');
+      categoryHeader.innerText = headerText;
       categoryHeader.classList = ['category'];
+      if (headerText == 'Combinados') {
+        categoryContents.classList.add('category-combinados');
+      }
       SUPPORT_ICON_DEFS[category].forEach(
         url => {
           var icon = document.createElement('img');


### PR DESCRIPTION
Adding new combined icons, from #55.
Resizing icon area to have 4 per row. Note that not all icons have the same width, height, neither the same aspect ratio. So some rows have 4, some have 2, some have more than 4. It is a bit messy, but seems to do the trick for what is requested in the issue.

<img width="966" alt="Screenshot 2024-04-01 at 18 03 58" src="https://github.com/inhodpr/receita-facil/assets/19919057/341ace5e-48f0-4336-9579-fdbd6a37b59a">
<img width="1182" alt="Screenshot 2024-04-01 at 18 04 22" src="https://github.com/inhodpr/receita-facil/assets/19919057/8ab20bb9-8003-4683-a4ee-3e062f28c776">
