### PR TITLE
Allow setting empty routes on admin panel.

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -35,6 +35,7 @@ class DrugForm(Form):
     is_image = BooleanField('Is Image?')
     is_link = BooleanField('Is Link?')
     route = SelectField(choices=[
+        '',
         'Uso oral',
         'Uso oral contínuo',
         'Uso Tópico',


### PR DESCRIPTION
Some drugs were wrongly set with non-empty drug route on the admin panel. This made it impossible to add them to the prescription with another route.

Example:
<img width="417" alt="Screenshot 2024-04-02 at 20 36 09" src="https://github.com/inhodpr/receita-facil/assets/19919057/82f20204-33a1-40d9-ad60-773d4b7b7687">

This allows us to set an empty route, which will make the UI respect the route selection box.
I already tried it on the test environment and edited the mentioned drug.