### PR TITLE
Bugfix icons container

### DIFF
--- a/static/css/common.css
+++ b/static/css/common.css
@@ -146,6 +146,7 @@ div.collapsed {
   .attribution,
   button,
   textarea,
+  .icon-options,
   .group-by-route img.unchecked,
   .instructions-for-doctors {
     display: none;

--- a/static/css/icon_select.css
+++ b/static/css/icon_select.css
@@ -1,13 +1,24 @@
 .icon-select .show-options {
     float: right;
 }
-.icon-select img {
+
+.icon-select .icon-options img {
     width: auto;
     height: 104px;
 }
+
+.icon-select .selected-icons img {
+    max-width: 100%;
+    max-height: 104px;
+    height: auto;
+    object-fit: contain;
+}
+
 .icon-select .selected-icons {
-    display: flex;
-    flex-wrap: nowrap;
+    display: grid;
+    grid-auto-flow: column;
+    max-height: 104px;
+    width: fit-content;
     margin: 1em;
 }
 .icon-select .selected-icons img {
@@ -15,7 +26,6 @@
 }
 .icon-select .icon-options {
     background-color: white;
-    float: right;
     width: 800px;
 }
 .icon-select .icon-options div.category {


### PR DESCRIPTION
#### Bugs:
1. **Overflow do container na impressão**: A seleção de múltiplos ícones com tamanho fixo causava o oversizing do container, fazendo com que as imagens ficassem fora da área de impressão.
2. **Impressão do container de opções de icones**: As opções dos ícones, quando não  minimizada, eram renderizadas junto na impressão e também causavam lentidão no processo do print;

#### Solução Aplicada:

* Isolado estilos das imagens que são de options e imagens selecionadas para não ter interferência;
* Removido o float das options para não ser arrastado junto com a seleção das imagens;
* Aplicado sistema de grid no container das imagens selecionadas para não ultrapassar o tamanho de 100% de container e reajustar seu tamanho para caber todas em uma linha só;
#### Exemplo do Bug antes do Fix:
![Screenshot before fix](https://github.com/user-attachments/assets/0490a6fd-7bde-450e-8204-c39159fc64e2)

#### Resultado após a solução:
![Screenshot after fix](https://github.com/user-attachments/assets/f8f7c906-3652-4ad0-970d-6479728eb2ca)
