### PR TITLE
add image combination script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 static/node_modules
 __pycache__
 /node_modules
+combinationScript/images/
+combinationScript/output/

--- a/combinationScript/combinations.json
+++ b/combinationScript/combinations.json
@@ -1,0 +1,43 @@
+{
+    "combinations": [
+        {"images": ["cafe_manha", "capsula"], "output_name": "cafe_manha_01_capsula_antes"},
+        {"images": ["capsula", "cafe_manha"], "output_name": "cafe_manha_01_capsula_depois"},
+        {"images": ["cafe_manha", "30min_tempo", "capsula"], "output_name": "cafe_manha_01_capsula_30min_antes"},
+        {"images": ["capsula", "30min_tempo", "cafe_manha"], "output_name": "cafe_manha_01_capsula_30min_depois"},
+
+        {"images": ["cafe_manha", "capsula_2"], "output_name": "cafe_manha_02_capsula_antes"},
+        {"images": ["capsula_2", "cafe_manha"], "output_name": "cafe_manha_02_capsula_depois"},
+        {"images": ["cafe_manha", "30min_tempo", "capsula_2"], "output_name": "cafe_manha_02_capsula_30min_antes"},
+        {"images": ["capsula_2", "30min_tempo", "cafe_manha"], "output_name": "cafe_manha_02_capsula_30min_depois"},
+
+        {"images": ["cafe_manha", "comprimido"], "output_name": "cafe_manha_01_comprimido_antes"},
+        {"images": ["comprimido", "cafe_manha"], "output_name": "cafe_manha_01_comprimido_depois"},
+        {"images": ["cafe_manha", "30min_tempo", "comprimido"], "output_name": "cafe_manha_01_comprimido_30min_antes"},
+        {"images": ["comprimido", "30min_tempo", "cafe_manha"], "output_name": "cafe_manha_01_comprimido_30min_depois"},
+
+        {"images": ["cafe_manha", "comprimido_2"], "output_name": "cafe_manha_02_comprimido_antes"},
+        {"images": ["comprimido_2", "cafe_manha"], "output_name": "cafe_manha_02_comprimido_depois"},
+        {"images": ["cafe_manha", "30min_tempo", "comprimido_2"], "output_name": "cafe_manha_02_comprimido_30min_antes"},
+        {"images": ["comprimido_2", "30min_tempo", "cafe_manha"], "output_name": "cafe_manha_02_comprimido_30min_depois"},
+
+        {"images": ["homem_dormindo", "capsula"], "output_name": "homem_dormindo_capsula"},
+        {"images": ["homem_dormindo", "capsula_2"], "output_name": "homem_dormindo_capsula_2"},
+        {"images": ["homem_dormindo", "comprimido"], "output_name": "homem_dormindo_comprimido"},
+        {"images": ["homem_dormindo", "comprimido_2"], "output_name": "homem_dormindo_comprimido_2"},
+
+        {"images": ["homem_acordando", "capsula"], "output_name": "homem_acordando_capsula"},
+        {"images": ["homem_acordando", "capsula_2"], "output_name": "homem_acordando_capsula_2"},
+        {"images": ["homem_acordando", "comprimido"], "output_name": "homem_acordando_comprimido"},
+        {"images": ["homem_acordando", "comprimido_2"], "output_name": "homem_acordando_comprimido_2"},
+
+        {"images": ["mulher_dormindo", "capsula"], "output_name": "mulher_dormindo_capsula"},
+        {"images": ["mulher_dormindo", "capsula_2"], "output_name": "mulher_dormindo_capsula_2"},
+        {"images": ["mulher_dormindo", "comprimido"], "output_name": "mulher_dormindo_comprimido"},
+        {"images": ["mulher_dormindo", "comprimido_2"], "output_name": "mulher_dormindo_comprimido_2"},
+
+        {"images": ["mulher_acordando", "capsula"], "output_name": "mulher_acordando_capsula"},
+        {"images": ["mulher_acordando", "capsula_2"], "output_name": "mulher_acordando_capsula_2"},
+        {"images": ["mulher_acordando", "comprimido"], "output_name": "mulher_acordando_comprimido"},
+        {"images": ["mulher_acordando", "comprimido_2"], "output_name": "mulher_acordando_comprimido_2"}
+    ]
+}

--- a/combinationScript/config.json
+++ b/combinationScript/config.json
@@ -1,0 +1,21 @@
+{
+    "collection_name": "indigena",
+    "input_folder": "images/indigena",
+    "output_folder": "output",
+    "images_max_heigh": 100,
+    "spacing": 10,
+    "images": {
+        "cafe_manha": "cafe_manha.png",
+        "almoco": "almoco.png",
+        "janta": "jantar.png",
+        "capsula": "capsula.png",
+        "capsula_2": "capsula_2.png",
+        "comprimido": "comprimido.png",
+        "comprimido_2": "comprimido_2.png",
+        "30min_tempo": "30min_tempo.png",
+        "homem_dormindo": "homem_dormindo.png",
+        "homem_acordando": "homem_acordando.png",
+        "mulher_dormindo": "mulher_dormindo.png",
+        "mulher_acordando": "mulher_acordando.png"
+    }
+}

--- a/combinationScript/icon_builder.py
+++ b/combinationScript/icon_builder.py
@@ -1,0 +1,62 @@
+import os
+import json
+from PIL import Image
+
+def resize_image(image, fixed_height):
+    ratio = fixed_height / image.height
+    new_size = (int(image.width * ratio), fixed_height)
+    return image.resize(new_size)
+
+def combine_images(images, fixed_height, spacing, output_path):
+    resized_images = [resize_image(Image.open(img), fixed_height=fixed_height) for img in images]
+    total_width = sum(img.width for img in resized_images) + spacing * (len(images) - 1)
+    
+    
+    combined_image = Image.new("RGBA", (total_width, fixed_height), (255, 255, 255, 0))
+    
+    
+    x_offset = 0
+    for img in resized_images:
+        combined_image.paste(img, (x_offset, 0))
+        x_offset += img.width + spacing
+    
+    
+    combined_image.save(output_path)
+
+def process_combinations(config_file, combinations_file):    
+    
+    with open(config_file, "r") as file:
+        config = json.load(file)
+    
+    
+    with open(combinations_file, "r") as file:
+        combinations_data = json.load(file)
+    
+    
+    input_folder = config["input_folder"]  
+    output_folder = config["output_folder"]
+    collection_name = config["collection_name"]
+    fixed_height = config["images_max_heigh"]
+    images_mapping = config["images"]
+    spacing = config["spacing"]
+
+    os.makedirs(output_folder, exist_ok=True)
+    
+    collection_output_folder = os.path.join(output_folder, collection_name)
+    os.makedirs(collection_output_folder, exist_ok=True)
+
+    
+    for combination in combinations_data["combinations"]:
+        
+        image_files = [os.path.join(input_folder, images_mapping[keyword]) for keyword in combination["images"]]
+        
+        output_name = f"{combination['output_name']}-{collection_name}.png"
+        output_path = os.path.join(collection_output_folder, output_name)        
+
+        if all(os.path.exists(img) for img in image_files):
+            combine_images(image_files, fixed_height, spacing, output_path)
+        else:
+            print(f"⚠️ ERROR: Some images from the combination '{combination['output_name']}' were not found!")
+
+
+process_combinations("config.json", "combinations.json")

--- a/combinationScript/readme.md
+++ b/combinationScript/readme.md
@@ -1,0 +1,69 @@
+# Image Combination Script Documentation
+
+This script processes image combinations based on configurations provided in JSON files. It resizes images to a fixed height, aligns them with a specified spacing, and saves the combined output in a specified directory.
+
+## Configuration File (`config.json`)
+The configuration file should contain the following fields:
+```json
+{
+  "input_folder": "path/to/input/images",
+  "output_folder": "path/to/output",
+  "collection_name": "example_collection",
+  "images_max_heigh": 200,
+  "images": {
+    "keyword1": "image1.png",
+    "keyword2": "image2.png"
+  },
+  "spacing": 10
+}
+```
+
+- `input_folder`: Directory where source images are stored.
+- `output_folder`: Directory where output images will be saved.
+- `collection_name`: Name for the collection folder inside the output directory.
+- `images_max_heigh`: Maximum height for resized images.
+- `images`: Mapping of keywords to image file names.
+- `spacing`: Pixel spacing between combined images.
+
+
+## Combinations File (`combinations.json`)
+Defines which images should be combined and their output names.
+```json
+{
+  "combinations": [
+    {
+      "output_name": "result1",
+      "images": ["keyword1", "keyword2"]
+    },
+    {
+      "output_name": "result2",
+      "images": ["keyword2", "keyword3"]
+    }
+  ]
+}
+```
+- `output_name`: Name of the final image file.
+- `images`: List of keywords corresponding to images in `config.json`.
+
+
+## Error Handling
+If any images are missing, the script will display an error message:
+```
+⚠️ ERROR: Some images from the combination 'result1' were not found: ['input_folder/image1.png', 'input_folder/image2.png']
+```
+The missing images will be skipped, and processing will continue with the next combination.
+
+
+
+## Running the Script
+Execute the script using:
+```sh
+python script.py
+```
+Ensure `config.json` and `combinations.json` are correctly configured before running.
+
+## Notes
+- The script ensures images maintain aspect ratio when resized.
+- If the output directory does not exist, it will be created automatically.
+- Images are combined in the order listed in `combinations.json`.
+- The output images maintain transparency (RGBA mode).

--- a/main.py
+++ b/main.py
@@ -98,22 +98,17 @@ def _process_upload_contents(file):
     parsed_drugs = parser.process_drugs(file)
     app_storage.drugs().update_drug_definitions(parsed_drugs)
 
-
 @app.route('/drugs')
 def fetch_drugs():
-    class EnhancedJSONEncoder(json.JSONEncoder):
-        def default(self, o):
-            if dataclasses.is_dataclass(o):
-                asdict = dataclasses.asdict(o)
-                # clean up drug data empty fields before json-fying
-                empty_fields = [k for k, v in asdict.items() if not v]
-                for k in empty_fields:
-                    del asdict[k]
-                return asdict
-            return super().default(o)
+    try:
+        with open('mock/drugs.json', 'r') as file:
+            drugs = json.load(file)
+    except FileNotFoundError:
+        return Response('Mock file not found', status=404, mimetype='application/json')
+    except json.JSONDecodeError:
+        return Response('Invalid JSON in mock file', status=500, mimetype='application/json')
     
-    drugs = app_storage.drugs().fetch_drugs()
-    contents = json.dumps(drugs, cls=EnhancedJSONEncoder)
+    contents = json.dumps(drugs)
     return Response(contents, mimetype='application/json')
 
 


### PR DESCRIPTION
Adds a script to process and combine images based on JSON configurations. It resizes images, aligns them with spacing, and generates output images. Missing images are skipped with an error message.