### PR TITLE
fix: drug description persisted incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ This is not an officially supported Google product.
    npm install
 3. Run the tests:
    ```bash
-   npm install
+   npm run test

--- a/static/js/app.mjs
+++ b/static/js/app.mjs
@@ -64,6 +64,14 @@ export default class ReceitaApp {
         }
     }
 
+    resetPrescription = function () {
+        this.prescriptionHandler.resetPrescription();
+    }
+
+    handleDrugRemove = function (drugId) {
+        this.prescriptionHandler.handleDrugRemove(drugId)
+    }
+
     generatePrescription = function () {
         var selectedDrugs = this.drugsHandler.getSelectedDrugs();
         this.prescriptionHandler.renderDrugs(selectedDrugs);

--- a/static/js/drugsForm.js
+++ b/static/js/drugsForm.js
@@ -13,6 +13,7 @@ class DrugSelectionHandler {
         delete this.drugsForm.routeMap[this.drugId];
         delete this.drugsForm.drugPosition[this.drugId];
         this.reassignDrugPositions();
+        this.drugsForm.app.handleDrugRemove(this.drugId)
     }
     this.drugsForm.app.generatePrescription();
   }
@@ -143,7 +144,8 @@ export default class DrugsForm {
     // Unselect all drugs.
     for (var idx in this.drugSelections) {
       this.drugSelections[idx].checked = false;
-    } 
+    }
+    this.app.resetPrescription(); 
     this.app.generatePrescription();
   }
 

--- a/static/js/receitaDiv.js
+++ b/static/js/receitaDiv.js
@@ -38,6 +38,16 @@ export default class ReceitaDiv {
     this.handleCustomizedText(e);
   }
 
+  handleDrugRemove = function (drugId) {
+    delete this.drugCustomText[drugId];
+    delete this.drugSupportIconSelectors[drugId];
+  }
+
+  resetPrescription = function () {
+    this.drugCustomText= {};
+    this.drugSupportIconSelectors= {};
+  }
+
   switchPrescriptionMode = function (enableSpecialPrescription) {
     if (this.prescriptionDiv) {
       this.prescriptionDiv.innerHTML = "";


### PR DESCRIPTION
Previously, the drug description was not resetting properly when deselecting and reselecting items. This was due to the prescription values not being cleared along with the drug selection. The fix ensures that prescription values are also reset when resetting drug selections, preventing outdated descriptions from persisting.