### PR TITLE
Adding new drug categorization + updates python version

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -154,12 +154,16 @@ def edit_drug(drug_id):
         return redirect('/admin')
     old_drug = app_storage.drugs().find_drug_by_id(drug_id)
     form = DrugForm(data=dataclasses.asdict(old_drug))
+    categories_v2 = json.dumps([
+        dataclasses.asdict(c) for c in old_drug.categories_v2
+    ])
     if request.method == 'GET':
         return render_template(
             "edit_drug.html",
             user_data=claims,
             error_message=error_message,
-            form=form
+            form=form,
+            categories_v2_json=categories_v2,
         )
     elif request.method == 'POST':
         new_drug, err = _parse_form_contents(request)
@@ -219,4 +223,5 @@ def supportIcons():
 
 
 if __name__ == "__main__":
+    os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = '/home/inhodpr/receita-facil/hellodpiresworld-df31830236b5.json'
     app.run(host="127.0.0.1", port=8080, debug=True)

--- a/app.yaml
+++ b/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: python38
+runtime: python39
 
 handlers:
 - url: /

--- a/scripts/drug.py
+++ b/scripts/drug.py
@@ -75,7 +75,10 @@ def from_entity(entity: Entity) -> Drug:
     if 'category' in entity:
         drug.category = entity['category']
     if 'categories_v2' in entity:
-        drug.categories_v2 = entity['categories_v2']
+        drug.categories_v2 = [
+            Category(c['top_level_group'], c['subgroup'])
+            for c in entity['categories_v2']
+        ]
     else:
         drug.categories_v2 = []
     if 'subcategory' in entity:

--- a/scripts/drug.py
+++ b/scripts/drug.py
@@ -74,7 +74,7 @@ def from_entity(entity: Entity) -> Drug:
         drug.brand = entity['brand']
     if 'category' in entity:
         drug.category = entity['category']
-    if 'categories_v2' in entity:
+    if 'categories_v2' in entity and entity['categories_v2']:
         drug.categories_v2 = [
             Category(c['top_level_group'], c['subgroup'])
             for c in entity['categories_v2']

--- a/scripts/drug.py
+++ b/scripts/drug.py
@@ -5,6 +5,12 @@ from google.cloud.datastore.entity import Entity
 from google.appengine.api import datastore_types
 
 
+@dataclasses.dataclass(init=True, frozen=True)
+class Category:
+    top_level_group: str | None = None
+    subgroup: str | None = None
+
+
 @dataclasses.dataclass(init=False, frozen=False)
 class Drug:
     id: int
@@ -35,6 +41,9 @@ class Drug:
     qr_code_url: str = None
     qr_code_subtitle: str = None
 
+    # New categories for new layout.
+    categories_v2: list[Category] = dataclasses.field(default_factory=list)
+
 
 def to_entity(drug: Drug, client: datastore.Client) -> Entity:
     entity = Entity(key=client.key('drug', drug.id))
@@ -44,17 +53,16 @@ def to_entity(drug: Drug, client: datastore.Client) -> Entity:
     # better for long text and is never indexed.
     curr_instructions_for_doctors = entity['instructions_for_doctors']
     entity['instructions_for_doctors'] = datastore_types.Text(curr_instructions_for_doctors)
+    
     entity.exclude_from_indexes.add('instructions_for_doctors')
+    entity.exclude_from_indexes.add('categories_v2')
+    
     return entity
 
 
 def from_entity(entity: Entity) -> Drug:
     drug = Drug()
-    if 'id' in entity:
-        drug.id = entity['id']
-    else:
-        drug.id = entity.key.id
-
+    drug.id = entity.key.id
     drug.name = entity['name']
     if 'quantity' in entity:
         drug.quantity = entity['quantity']
@@ -66,6 +74,10 @@ def from_entity(entity: Entity) -> Drug:
         drug.brand = entity['brand']
     if 'category' in entity:
         drug.category = entity['category']
+    if 'categories_v2' in entity:
+        drug.categories_v2 = entity['categories_v2']
+    else:
+        drug.categories_v2 = []
     if 'subcategory' in entity:
         drug.subcategory = entity['subcategory']
     if 'support_icons' in entity:
@@ -97,6 +109,10 @@ def from_json(obj: Any) -> Drug:
         drug.brand = obj['brand']
     if 'category' in obj:
         drug.category = obj['category']
+    if 'categories_v2' in obj:
+        drug.categories_v2 = obj['categories_v2']
+    else:
+        drug.categories_v2 = []
     if 'subcategory' in obj:
         drug.subcategory = obj['subcategory']
     if 'support_icons' in obj:

--- a/static/js/categoriesV2Editor.js
+++ b/static/js/categoriesV2Editor.js
@@ -1,0 +1,65 @@
+export default class CategoriesV2Editor {
+
+    constructor(current_categories) {
+        this.current_categories = current_categories;
+    }
+
+    render = function(parent) {
+        this.current_categories.array.forEach(element => {
+            renderSingleCategory(element, parent);
+        });
+    }
+
+    renderSingleCategory = function(element, parent) {
+        var idx = parent.childElementCount;
+        var root = document.createElement('div');
+        var topLevelSelect = document.createElement('input');
+        var subcategory = document.createElement('input');
+        var labelTopLevelSelect = document.createElement('label');
+        var labelSubcategory = document.createElement('label');
+        topLevelSelect.id = "top-level-category-" + idx;
+        topLevelSelect.type = "select";
+        labelTopLevelSelect.for = topLevelSelect.id;
+        subcategory.id = "subcategory-" + idx;
+        subcategory.type = "text";
+        labelSubcategory.for = subcategory.id;
+
+        var options = [
+            "Uso racional de antibióticos em APS",
+            "*DELETAR*",
+            "Cardiovascular",
+            "Condutas",
+            "Dermatologia",
+            "Doenças que não podem ser neglicenciadas",
+            "Endocrinologia",
+            "Gastrologia",
+            "Neurologia",
+            "Oftalmologia",
+            "Otorrinolaringologia",
+            "Pediatria",
+            "Respiratório",
+            "Reumatologia",
+            "Saúde da mulher",
+            "Saúde do homem",
+            "Saúde mental",
+            "Sintomáticos",
+            "Sintomáticos injetáveis",
+        ];
+        options.forEach(option => {
+            var optNode = document.createElement("option");
+            optNode.innerText = option;
+            topLevelSelect.appendChild(option);
+        });
+        
+        root.classList.add("single-categories-v2-container");
+        var topLevelDiv = document.createElement('div');
+        var subcategoryDiv = document.createElement('div');
+        topLevelDiv.appendChild(labelTopLevelSelect);
+        topLevelDiv.appendChild(topLevelSelect);
+        subcategoryDiv.appendChild(labelSubcategory);
+        subcategoryDiv.appendChild(subcategory);
+        root.appendChild(topLevelDiv);
+        root.appendChild(subcategoryDiv);
+        return root;
+    }
+}

--- a/templates/edit_drug.html
+++ b/templates/edit_drug.html
@@ -21,8 +21,13 @@
   <link type="text/css" rel="stylesheet" href="/admin/static/css/admin.css">
   <link type="text/css" rel="stylesheet" href="/admin/static/css/icon_select.css">
   <script type="module">
+    import CategoriesV2Editor from '/admin/static/js/categoriesV2Editor.js';
     import IconSelect from '/admin/static/js/iconSelect.js';
+
+    var current_categories = JSON.parse('{{ categories_v2_json|safe }}');
+
     window.addEventListener('load', function() {
+      // Initialize support icons selector.
       var iconSelector = new IconSelect();
       var currentIconsStr = '{{ form.support_icons.data or "" }}';
       iconSelector.iconDefsUrl = '/admin/supportIconDefs';
@@ -31,6 +36,12 @@
       }
       iconSelector.start();
       document.getElementById('support-icons-div').appendChild(iconSelector.root);
+
+      // Initialize categories_v2 selector.
+      categoriesV2Editor = new CategoriesV2Editor(current_categories);
+      categoriesV2Editor.render(document.getElementById("categories-v2-root"));
+
+      // Set up form onsubmit events.
       document.getElementById('drug-form').addEventListener('submit', function () {
         var supportIconsField = document.getElementById('support_icons');
         supportIconsField.value = iconSelector.selectedUrls;
@@ -59,6 +70,7 @@
             {{ render_field(form.brand) }}
             {{ render_field(form.category) }}
             {{ render_field(form.subcategory) }}
+            <div id="categories-v2-root"></div>
             {{ render_field(form.instructions) }}
             {{ render_field(form.instructions_for_doctors) }}
             {{ render_field(form.route) }}


### PR DESCRIPTION
Must also update python version since v3.8 is no longer supported.

The new categories are already loaded on the DB. We need to teach the server how to read and export them. This PR does just that.

Here is how it gets sent over JSON:
![image](https://github.com/user-attachments/assets/003e525f-2ce7-4306-8b4f-8b268bd993f1)

There are still some categories to fix on the DB. Namely, videos and images are showing up as `*DELETAR*`, and we decided to keep them a bit longer.