### PR TITLE
Updating python version on admin panel and removing type unions from drug.Category

### DIFF
--- a/admin_service.yaml
+++ b/admin_service.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: python38
+runtime: python39
 service: admin
 entrypoint: 'gunicorn -b :$PORT admin:app'
 

--- a/scripts/drug.py
+++ b/scripts/drug.py
@@ -7,8 +7,8 @@ from google.appengine.api import datastore_types
 
 @dataclasses.dataclass(init=True, frozen=True)
 class Category:
-    top_level_group: str | None = None
-    subgroup: str | None = None
+    top_level_group: str = None
+    subgroup: str = None
 
 
 @dataclasses.dataclass(init=False, frozen=False)


### PR DESCRIPTION
Need to update python version on admin panel as well.
Also, type unions are not supported. So I'm removing them from drug.Category dataclass.

The last update broke the admin panel. This should fix it. At least it is already working on the latest version on appengine, uploaded from my machine.
https://admin-dot-hellodpiresworld.appspot.com/