### PR TITLE
Enable CORS for the Flask app to allow cross-origin requests

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,10 +21,12 @@ from scripts import knowledge_base, process_drugs
 
 from collections import namedtuple
 from flask import Flask, render_template, request, redirect, Response
+from flask_cors import CORS
 
 
 app = Flask(__name__)
 app_storage = storage_defs.Storage()
+CORS(app)
 
 
 ALLOWED_EXTENSIONS = ['txt']


### PR DESCRIPTION
Enable CORS in Flask to allow cross-origin requests between the new frontend and old backend.