### PR TITLE
Adding a parameter for loading next version of support icons

### DIFF
--- a/main.py
+++ b/main.py
@@ -165,7 +165,15 @@ def fetch_bottoms():
 
 @app.route('/supportIcons')
 def support_icons_defs():
-    support_icons_defs = app_storage.support_icons().fetch_support_icons_definitions()
+    icon_storage = app_storage.support_icons()
+    requested_version = request.args.get('version', None)
+    if requested_version and requested_version in icon_storage.Version.__members__:
+        version = icon_storage.Version[requested_version]
+    else:
+        version = icon_storage.Version.V1
+    support_icons_defs = icon_storage.fetch_support_icons_definitions(
+        version=version
+    )
     contents = json.dumps(support_icons_defs)
     return Response(contents, mimetype='application/json')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 appengine-python-standard
-flask==2.3.2
+flask==2.3.
+flask-cors
 Flask-WTF
 google-cloud-datastore
 google-cloud-storage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appengine-python-standard
-flask==2.3.
+flask==2.3.2
 flask-cors
 Flask-WTF
 google-cloud-datastore

--- a/scripts/on_disk_support_icons_storage.py
+++ b/scripts/on_disk_support_icons_storage.py
@@ -1,24 +1,31 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from scripts import storage as support_icon_storage
 
 from google.cloud import storage
 
 
-SUPPORT_ICONS_BUCKET = 'receita-facil-support-icons'
+SUPPORT_ICONS_BUCKET_V1 = 'receita-facil-support-icons'
+SUPPORT_ICONS_BUCKET_V2 = 'receita-facil-support-icons-v2'
 
 
 class OnDiskSupportIconsStorage(support_icon_storage.SupportIconsStorage):
     def __init__(self):
         self._client = storage.Client(project='hellodpiresworld')
 
-    def fetch_support_icons_definitions(self) -> Dict[str, List[str]]:
-        blobs = self._client.list_blobs(SUPPORT_ICONS_BUCKET)
+    def fetch_support_icons_definitions(
+        self,
+        version: Optional[support_icon_storage.SupportIconsStorage.Version] = None) -> Dict[str, List[str]]:
+        bucket = SUPPORT_ICONS_BUCKET_V2 if version == self.Version.V2 else SUPPORT_ICONS_BUCKET_V1
+        allowed_extensions = {'.png', '.svg'}
+        blobs = self._client.list_blobs(bucket)
         support_icon_defs = {}
         for blob in blobs:
             category, _ = blob.name.split('/')
             if category not in support_icon_defs:
                 support_icon_defs[category] = []
-            if blob.public_url and blob.public_url.endswith('.png'):
+            public_url = blob.public_url
+            extension = public_url[public_url.rfind('.'):]
+            if extension in allowed_extensions:
                 support_icon_defs[category].append(blob.public_url)
         return support_icon_defs

--- a/scripts/storage.py
+++ b/scripts/storage.py
@@ -1,7 +1,9 @@
+import enum
+
 from scripts.drug import Drug
 from scripts.user import User
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 class DrugsStorage:
     def fetch_drugs(self) -> List[Drug]:
@@ -29,7 +31,13 @@ class FootnotesStorage:
 
 
 class SupportIconsStorage:
-    def fetch_support_icons_definitions(self) -> Dict[str, List[str]]:
+    class Version(enum.IntEnum):
+        V1 = 1
+        V2 = 2
+    
+    def fetch_support_icons_definitions(
+        self,
+        version: Optional[Version] = None) -> Dict[str, List[str]]:
         raise NotImplementedError()
 
 


### PR DESCRIPTION
This way we don't break the current platform and still allow the next version to access the new icones from the server.

Icons on the next version can be loaded with:
https://<server>/supportIcons?version=V2

Not adding the version=V2, or asking explicitly for version=V1, will load the current icons.

Test version up with this change:
https://20250323t224040-dot-hellodpiresworld.appspot.com/#